### PR TITLE
Mute player before recording the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CS:GO Demo Utilities
 This is a collection of tools that I use when I play Counter-Strike: Global Offensive. They help me to record POV demos when I'm playing competitive matches. For information on what drove me to make this, see the [background section](#background) which I've mercifully moved to the bottom of the README because there's a lot to explain.
-
+ 
 ## Features
 Here are the features provided by this set of tools. They can all be configured through a `config.ini` that you will create in the installation process.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This allows you to record your own voice in POV demos without having to hear you
 
 Typically, if you want your voice to be audible in your POV demos, you have to turn on `voice_loopback` which will make you hear yourself twice. The solution is to turn on `voice_loopback` but turn down the volume of your voice to 0 with the `voice_player_volume` command. DemoRecordingHelper automates this process and can be configured in the `demo_recording_helper` section of your `config.ini` file.
 
-DemoPlaybackHelper is responsible for _unmuting_ the player who was muted by DemoRecordingHelper (if any).
+DemoPlaybackHelper ~~is~~ was previously responsible for _unmuting_ the player who was muted by DemoRecordingHelper (if any). As of version 1.1.0, it is no longer necessary to keep CS:GO Demo Helper running while playing a demo. However, demos recorded with versions of this tool prior to 1.1.0 will still need CS:GO Demo Helper running to unmute your voice.
 
 ## Installation
 Installation is a piece of cake, but you will need to have a teensy bit of rudimentary knowledge on how to get around the command-line on your OS. This tool should work on any OS that CS:GO runs on.

--- a/src/services/DemoPlaybackHelper.ts
+++ b/src/services/DemoPlaybackHelper.ts
@@ -1,5 +1,9 @@
 /*
  * See the top comment of DemoRecordingHelper for an explanation of what this class is responsible for.
+ *
+ * NOTE: YOU NO LONGER NEED TO HAVE THIS RUNNING WHEN PERFORMING DEMO PLAYBACK UNLESS THE DEMO WAS RECORDED
+ * WITH A VERSION EARLIER THAN 1.1.0!!! You'll know if you need this running if you
+ * notice yourself talking during demo playback but don't hear any audio.
  */
 
 import {Config} from "../utils/Config";
@@ -8,6 +12,12 @@ import {LogHelper} from "../utils/LogHelper";
 import {SubscriberManager} from "../utils/SubscriberManager";
 import {DemoRecordingHelper} from "./DemoRecordingHelper";
 
+/**
+ * DemoPlaybackHelper is responsible for listening to the console for messages left behind by DemoRecordingHelper.
+ * For instance, a message about a player being muted might have been left behind and DemoPlaybackHelper acts on this
+ * information by unmuting the player. This is just an example of its purpose and isn't actually necessary any more
+ * with demos recorded after the changes made in 1.1.0.
+ */
 export class DemoPlaybackHelper implements ListenerService {
     private static readonly log = LogHelper.getLogger('DemoPlaybackHelper');
     // private static readonly demoPlaybackRegExp = RegExp('^Playing demo from (.*)\\.dem\\.$');

--- a/src/services/DemoRecordingHelper.ts
+++ b/src/services/DemoRecordingHelper.ts
@@ -183,6 +183,8 @@ export class DemoRecordingHelper implements ListenerService {
     }
 
     private static async attemptStartRecording(demoName: string) {
+        await DemoRecordingHelper.applyRecordingPreferences();
+        DemoRecordingHelper.log.info(`Attempting to start recording...`);
         const recordResultLine = await SubscriberManager.searchForValue(`record ${demoName}`, DemoRecordingHelper.resultOfRecordCmdRegExp, false);
         const match = DemoRecordingHelper.resultOfRecordCmdRegExp.exec(recordResultLine);
         if (!match)
@@ -197,8 +199,6 @@ export class DemoRecordingHelper implements ListenerService {
             DemoRecordingHelper.log.info(match[2]);
             DemoRecordingHelper.log.info(`DemoHelper started recording demo '${match[3]}' successfully!`);
             DemoRecordingHelper.currentlyRecording = true;
-            await DemoRecordingHelper.applyRecordingPreferences();
-            DemoRecordingHelper.log.info(`Applied recording preferences and recorded a message in demo '${match[3]}'.`);
             ConsoleHelper.padConsole(5);
             SubscriberManager.sendMessage(`echo DemoHelper applied recording preferences and recorded a message in demo successfully!`);
         } else if (match[4]) {


### PR DESCRIPTION
Currently, DemoRecordingHelper will run the command to mute the person recording the demo with _after_ the demo recording begins. The problem with this is that 

In hindsight it would have been way better to run the command that mutes myself _before_ the demo recording starts. That way, the demo doesn't even _need_ the playback helper running for my own voice to be audible.