### PR TITLE
Fix main branch being misnamed in release-management.yml

### DIFF
--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_draft_release:


### PR DESCRIPTION
#5 Had a mistake in it and I didn't notice it until after I had merged it. This PR fixes that.