### PR TITLE
Partial fix for #32

### DIFF
--- a/src/services/DemoRecordingHelper.ts
+++ b/src/services/DemoRecordingHelper.ts
@@ -212,7 +212,7 @@ export class DemoRecordingHelper implements ListenerService {
         } else if (match![4]) {
             //Please start demo recording after current round is over.
             // noinspection SpellCheckingInspection
-            SubscriberManagerFactory.getSubscriberManager().sendMessage(['echo Failed to begin recording demo because a round was already in progress. Waiting for next round.', `If recording doesn't start on the next round, you may issue the command 'echo dh roundover' to begin recording.`]);
+            SubscriberManagerFactory.getSubscriberManager().sendMessage(['echo Failed to begin recording demo because a round was already in progress. Waiting for next round.', `echo If recording doesn't start on the next round, you may issue the command 'echo dh roundover' to begin recording.`]);
             await SubscriberManagerFactory.getSubscriberManager().searchForValue('echo', DemoRecordingHelper.beginRecordingAfterNewRoundRegExp, false);
             await this.attemptStartRecording(demoName);
         }


### PR DESCRIPTION
The console printing "Unknown command: If" was caused by a missing echo command in the message sent to the user in this case. Everything else about this branch of the logic may be functional. I never gave it enough time to see if it was properly working before I assumed there was an issue because of the command error printed to console. This should be merged into the main branch and then #32 should be monitored to see if recording is able to begin successfully after the round ends.